### PR TITLE
Reverse carousel arrows for Persian

### DIFF
--- a/src/pages/NoraStudio.tsx
+++ b/src/pages/NoraStudio.tsx
@@ -269,7 +269,7 @@ export default function NoraStudio() {
                       aria-label="قبلی"
                       onClick={goToPreviousSlide}
                     >
-                      <ChevronRight className="h-5 w-5" />
+                      <ChevronLeft className="h-5 w-5" />
                     </Button>
                     <div className="flex justify-center gap-2">
                       {category.images.map((_, index) => (
@@ -289,7 +289,7 @@ export default function NoraStudio() {
                       aria-label="بعدی"
                       onClick={goToNextSlide}
                     >
-                      <ChevronLeft className="h-5 w-5" />
+                      <ChevronRight className="h-5 w-5" />
                     </Button>
                   </div>
 


### PR DESCRIPTION
Correct image navigation arrow directions in the portfolio section for Persian (RTL) layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-a59ff2c9-6ca6-4ee8-a418-7d9815863e03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a59ff2c9-6ca6-4ee8-a418-7d9815863e03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

