### PR TITLE
Reverse carousel arrows for Persian

### DIFF
--- a/src/pages/NoraStudio.tsx
+++ b/src/pages/NoraStudio.tsx
@@ -269,7 +269,7 @@ export default function NoraStudio() {
                       aria-label="قبلی"
                       onClick={goToPreviousSlide}
                     >
-                      <ChevronRight className="h-5 w-5" />
+                      <ChevronLeft className="h-5 w-5" />
                     </Button>
                     <div className="flex justify-center gap-2">
                       {category.images.map((_, index) => (
@@ -289,7 +289,7 @@ export default function NoraStudio() {
                       aria-label="بعدی"
                       onClick={goToNextSlide}
                     >
-                      <ChevronLeft className="h-5 w-5" />
+                      <ChevronRight className="h-5 w-5" />
                     </Button>
                   </div>
 


### PR DESCRIPTION
Swap portfolio slider chevron icons to match Persian (RTL) direction.

---
<a href="https://cursor.com/background-agent?bcId=bc-7516e944-a974-467e-adb7-b745199fa613">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7516e944-a974-467e-adb7-b745199fa613">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

