### PR TITLE
Reverse arrows and darken contact backgrounds

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -247,7 +247,7 @@ export default function Contact() {
         </section>
         
         {/* FAQ Section */}
-        <section className="section bg-muted">
+        <section className="section bg-secondary/50 dark:bg-secondary/20">
           <div className="container">
             <div className="max-w-3xl mx-auto text-center mb-12 animate-fade-in">
               <h2 className="text-3xl font-bold mb-4">{t.contact.faq}</h2>

--- a/src/pages/NoraStudio.tsx
+++ b/src/pages/NoraStudio.tsx
@@ -269,7 +269,7 @@ export default function NoraStudio() {
                       aria-label="قبلی"
                       onClick={goToPreviousSlide}
                     >
-                      <ChevronLeft className="h-5 w-5" />
+                      <ChevronRight className="h-5 w-5" />
                     </Button>
                     <div className="flex justify-center gap-2">
                       {category.images.map((_, index) => (
@@ -289,7 +289,7 @@ export default function NoraStudio() {
                       aria-label="بعدی"
                       onClick={goToNextSlide}
                     >
-                      <ChevronRight className="h-5 w-5" />
+                      <ChevronLeft className="h-5 w-5" />
                     </Button>
                   </div>
 


### PR DESCRIPTION
Flip homepage portfolio arrows and darken Contact page FAQ section background to better match the site's dark theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-3fabe19f-44ab-494c-b069-2ccc40d44b83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3fabe19f-44ab-494c-b069-2ccc40d44b83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

