### PR TITLE
Reverse arrows and darken contact backgrounds

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -84,7 +84,7 @@ export default function Contact() {
               <div className="animate-fade-in anim-delay-100">
                 <h2 className="text-2xl font-bold mb-6">{t.contact.getInTouch}</h2>
                 
-                <div className="glass-card p-6 space-y-6 mb-8 bg-white/90 dark:bg-charcoal/90">
+                <div className="glass-card p-6 space-y-6 mb-8">
                   <div className="flex items-start">
                     <div className="flex-shrink-0 h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center mr-4">
                       <MapPin className="h-5 w-5 text-primary" />
@@ -153,7 +153,7 @@ export default function Contact() {
               <div className="animate-fade-in anim-delay-300">
                 <h2 className="text-2xl font-bold mb-6">{t.contact.sendMessage}</h2>
                 
-                <div className="glass-card p-6 bg-white/90 dark:bg-charcoal/90">
+                <div className="glass-card p-6">
                   {!isSubmitted ? (
                     <form onSubmit={handleSubmit} className="space-y-6">
                       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -283,7 +283,7 @@ export default function Contact() {
                   icon: <MapPin className="h-5 w-5 text-primary" />
                 },
               ].map((faq, index) => (
-                <div key={index} className="glass-card p-6 bg-white/90 dark:bg-charcoal/90">
+                <div key={index} className="glass-card p-6">
                   <h3 className="font-semibold text-lg mb-2">
                     {t.contact.questions[faq.questionKey].question}
                   </h3>

--- a/src/pages/NoraStudio.tsx
+++ b/src/pages/NoraStudio.tsx
@@ -266,10 +266,10 @@ export default function NoraStudio() {
                     <Button
                       variant="outline"
                       size="icon"
-                      aria-label="بعدی"
-                      onClick={goToNextSlide}
+                      aria-label="قبلی"
+                      onClick={goToPreviousSlide}
                     >
-                      <ChevronRight className="h-5 w-5" />
+                      <ChevronLeft className="h-5 w-5" />
                     </Button>
                     <div className="flex justify-center gap-2">
                       {category.images.map((_, index) => (
@@ -286,10 +286,10 @@ export default function NoraStudio() {
                     <Button
                       variant="outline"
                       size="icon"
-                      aria-label="قبلی"
-                      onClick={goToPreviousSlide}
+                      aria-label="بعدی"
+                      onClick={goToNextSlide}
                     >
-                      <ChevronLeft className="h-5 w-5" />
+                      <ChevronRight className="h-5 w-5" />
                     </Button>
                   </div>
 


### PR DESCRIPTION
Reverse portfolio slider arrows and align contact section backgrounds with the site's `glass-card` theme.

The contact section's custom background classes (`bg-white/90 dark:bg-charcoal/90`) were overriding the intended `glass-card` styling, causing a visual inconsistency. Removing these custom classes ensures the section adheres to the site's defined theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c707053-91c2-4746-bf92-fe4a75186e13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c707053-91c2-4746-bf92-fe4a75186e13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

